### PR TITLE
Support Steal 1.0

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -14,10 +14,12 @@ module.exports = function(options, buildResult){
 	// Set the bundlesPath as a file to use.
 	var files = nwOptions.files || nwOptions.glob || [];
 	files = Array.isArray(files) ? files : [files];
-	if(buildResult && buildResult.configuration &&
-	   buildResult.configuration.bundlesPath) {
-		var bundlesPath = buildResult.configuration.bundlesPath;
-		var globPath = path.relative(process.cwd(), bundlesPath) + "/**/*";
+
+	var buildConfig = buildResult && buildResult.configuration;
+	var destPath = buildConfig && (buildConfig.dest || buildConfig.bundlesPath);
+
+	if(destPath) {
+		var globPath = path.relative(process.cwd(), destPath) + "/**/*";
 		files.unshift(globPath);
 	}
 	nwOptions.files = files;


### PR DESCRIPTION
Steal 1.0 includes a new dest option that replaces bundlesPath. This
change makes it so that we support both.